### PR TITLE
Add status option to Debian init script

### DIFF
--- a/debian/dante-server.init
+++ b/debian/dante-server.init
@@ -20,6 +20,9 @@ CONFFILE=/etc/$NAME.conf
 
 test -f $DAEMON || exit 0
 
+test -f /lib/lsb/init-functions || exit 1
+. /lib/lsb/init-functions
+
 set -e
 
 # This function makes sure that the Dante server can write to the pid-file.
@@ -80,6 +83,9 @@ case "$1" in
 	start-stop-daemon --start --quiet --pidfile $PIDFILE \
 	  --exec $DAEMON -- -D
 	echo "$NAME."
+	;;
+status)
+	status_of_proc "$DAEMON" $DESC && exit 0 || exit $?
 	;;
   *)
 	N=/etc/init.d/$NAME


### PR DESCRIPTION
Adds a status option to the Debian init script.

When managing a Dante server using the Puppet configuration management
tool, the Puppet `Service` resource uses status to determine if a
service is running or not.  Without a status resource Puppet will
run `/etc/init.d/danted start` even if the service is already
running.

Example use:

```
$ service danted status
 * Dante is not running
$ sudo service danted start
Starting Dante SOCKS daemon: Apr 26 12:08:20 (1524744500) danted[2058]:
socks_seteuid(): old: 0, new: 13
Apr 26 12:08:20 (1524744500) danted[2058]: socks_reseteuid(): current:
13, new: 0
Apr 26 12:08:20 (1524744500) danted[2058]: socks_seteuid(): old: 0, new:
65534
Apr 26 12:08:20 (1524744500) danted[2058]: socks_reseteuid(): current:
65534, new: 0
Apr 26 12:08:20 (1524744500) danted[2058]: socks_seteuid(): old: 0, new:
65534
Apr 26 12:08:20 (1524744500) danted[2058]: socks_reseteuid(): current:
65534, new: 0
danted.
$ service danted status
 * Dante is running
```